### PR TITLE
Port from GConf

### DIFF
--- a/speech_gst.py
+++ b/speech_gst.py
@@ -43,8 +43,8 @@ def _message_cb(bus, message, pipe):
         if pipe is play_speaker[1]:
             speech.reset_cb()
     elif message.type == Gst.MessageType.ELEMENT and \
-            message.structure.get_name() == 'espeak-mark':
-        mark = message.structure['mark']
+            message.get_structure().get_name() == 'espeak-mark':
+        mark = message.get_structure()['mark']
         speech.highlight_cb(int(mark))
 
 

--- a/speechtoolbar.py
+++ b/speechtoolbar.py
@@ -19,7 +19,6 @@ import json
 from gettext import gettext as _
 
 from gi.repository import Gtk
-from gi.repository import GConf
 
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.toggletoolbutton import ToggleToolButton
@@ -38,7 +37,6 @@ class SpeechToolbar(Gtk.Toolbar):
             return
         self.is_paused = False
 
-        self._cnf_client = GConf.Client.get_default()
         self.load_speech_parameters()
 
         self.sorted_voices = [i for i in speech.voices()]
@@ -99,23 +97,6 @@ class SpeechToolbar(Gtk.Toolbar):
                 speech.voice = speech_parameters['voice']
             finally:
                 f.close()
-
-        self._cnf_client.add_dir('/desktop/sugar/speech',
-                                 GConf.ClientPreloadType.PRELOAD_NONE)
-        speech.pitch = self._cnf_client.get_int('/desktop/sugar/speech/pitch')
-        speech.rate = self._cnf_client.get_int('/desktop/sugar/speech/rate')
-        self._cnf_client.notify_add('/desktop/sugar/speech/pitch',
-                                    self.__conf_changed_cb, None)
-        self._cnf_client.notify_add('/desktop/sugar/speech/rate',
-                                    self.__conf_changed_cb, None)
-
-    def __conf_changed_cb(self, client, connection_id, entry, args):
-        key = entry.get_key()
-        value = client.get_int(key)
-        if key == '/desktop/sugar/speech/pitch':
-            speech.pitch = value
-        if key == '/desktop/sugar/speech/rate':
-            speech.rate = value
 
     def save_speech_parameters(self):
         speech_parameters = {}


### PR DESCRIPTION
GConf is part of GTK+ 2 and will not be available.  Read used GConf to get the speech rate and pitch set by Sugar Frame.  Only the text adapter has speech support.

Remove the rate and pitch, and use defaults only.

Test method is to start Write, type some text, save as text, open Journal, resume the text using Read, click on the speech toolbar, and press play.
