### PR TITLE
Resume journal object of content type application/pdf

### DIFF
--- a/readactivity.py
+++ b/readactivity.py
@@ -93,13 +93,13 @@ def _get_screen_dpi():
 def get_md5(filename):
     # FIXME: Should be moved somewhere else
     filename = filename.replace('file://', '')  # XXX: hack
-    fh = open(filename)
+    fh = open(filename, encoding='ISO-8859-1')
     digest = hashlib.md5()
     while 1:
         buf = fh.read(4096)
         if buf == "":
             break
-        digest.update(buf)
+        digest.update(buf.encode('utf-8'))
     fh.close()
     return digest.hexdigest()
 


### PR DESCRIPTION
Fixes #36 

Useful Links
https://stackoverflow.com/questions/19699367/unicodedecodeerror-utf-8-codec-cant-decode-byte
https://stackoverflow.com/questions/6683167/how-to-fix-unicode-encode-error-using-the-hashlib-module

Kindly review.
Tested on Ubuntu 18.04, Sugar v0.114