### PR TITLE
Add feature of inverted colors for EvinceViewer

### DIFF
--- a/icons/dark-theme.svg
+++ b/icons/dark-theme.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32px"
+   height="32px"
+   id="svg2985"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="dark-theme.svg">
+  <defs
+     id="defs2987" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.219689"
+     inkscape:cx="12.682313"
+     inkscape:cy="14.416406"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:snap-global="false"
+     objecttolerance="10000"
+     guidetolerance="10000"
+     showguides="false"
+     inkscape:window-width="1360"
+     inkscape:window-height="712"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,32"
+       id="guide3767" />
+    <sodipodi:guide
+       position="32,0"
+       orientation="-32,0"
+       id="guide3769" />
+    <sodipodi:guide
+       position="32,32"
+       orientation="0,-32"
+       id="guide3771" />
+    <sodipodi:guide
+       position="0,32"
+       orientation="32,0"
+       id="guide3773" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid3775"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,32"
+       id="guide3777" />
+    <sodipodi:guide
+       position="32,0"
+       orientation="-32,0"
+       id="guide3779" />
+    <sodipodi:guide
+       position="32,32"
+       orientation="0,-32"
+       id="guide3781" />
+    <sodipodi:guide
+       position="0,32"
+       orientation="32,0"
+       id="guide3783" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,32"
+       id="guide3785" />
+    <sodipodi:guide
+       position="32,0"
+       orientation="-32,0"
+       id="guide3787" />
+    <sodipodi:guide
+       position="32,32"
+       orientation="0,-32"
+       id="guide3789" />
+    <sodipodi:guide
+       position="0,32"
+       orientation="32,0"
+       id="guide3791" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect2993"
+       width="31.022896"
+       height="31.194761"
+       x="0.66299194"
+       y="0.60228604"
+       ry="2.9258621" />
+    <text
+       xml:space="preserve"
+       style="font-size:11.23703003px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="5.8393445"
+       y="26.455677"
+       id="text3763"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3765"
+         x="5.8393445"
+         y="26.455677"
+         style="font-size:30.90183258px;fill:#ffffff;fill-opacity:1">A</tspan></text>
+  </g>
+</svg>

--- a/icons/light-theme.svg
+++ b/icons/light-theme.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32px"
+   height="32px"
+   id="svg2985"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="dark-theme.svg">
+  <defs
+     id="defs2987" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.219689"
+     inkscape:cx="12.682313"
+     inkscape:cy="14.416406"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:snap-global="false"
+     objecttolerance="10000"
+     guidetolerance="10000"
+     showguides="false"
+     inkscape:window-width="1360"
+     inkscape:window-height="712"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,32"
+       id="guide3767" />
+    <sodipodi:guide
+       position="32,0"
+       orientation="-32,0"
+       id="guide3769" />
+    <sodipodi:guide
+       position="32,32"
+       orientation="0,-32"
+       id="guide3771" />
+    <sodipodi:guide
+       position="0,32"
+       orientation="32,0"
+       id="guide3773" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid3775"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,32"
+       id="guide3777" />
+    <sodipodi:guide
+       position="32,0"
+       orientation="-32,0"
+       id="guide3779" />
+    <sodipodi:guide
+       position="32,32"
+       orientation="0,-32"
+       id="guide3781" />
+    <sodipodi:guide
+       position="0,32"
+       orientation="32,0"
+       id="guide3783" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,32"
+       id="guide3785" />
+    <sodipodi:guide
+       position="32,0"
+       orientation="-32,0"
+       id="guide3787" />
+    <sodipodi:guide
+       position="32,32"
+       orientation="0,-32"
+       id="guide3789" />
+    <sodipodi:guide
+       position="0,32"
+       orientation="32,0"
+       id="guide3791" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect2993"
+       width="31.022896"
+       height="31.194761"
+       x="0.66299194"
+       y="0.60228604"
+       ry="2.9258621" />
+    <text
+       xml:space="preserve"
+       style="font-size:11.23703002999999967px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="5.8393445"
+       y="26.455677"
+       id="text3763"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3765"
+         x="5.8393445"
+         y="26.455677"
+         style="font-size:30.90183258000000066px;fill:#000000;fill-opacity:1">A</tspan></text>
+  </g>
+</svg>

--- a/po/Read.pot
+++ b/po/Read.pot
@@ -207,12 +207,20 @@ msgstr ""
 msgid "Rotate right"
 msgstr ""
 
+#: readtoolbar.py:270 readtoolbar.py:348
+msgid "Inverted Colors"
+msgstr ""
+
 #: readtoolbar.py:324
 msgid "Show Tray"
 msgstr ""
 
 #: readtoolbar.py:326
 msgid "Hide Tray"
+msgstr ""
+
+#: readtoolbar.py:345
+msgid "Normal Colors"
 msgstr ""
 
 #: speechtoolbar.py:65

--- a/readactivity.py
+++ b/readactivity.py
@@ -238,6 +238,8 @@ class ReadActivity(activity.Activity):
                                    self.__toogle_navigator_cb)
         self._view_toolbar.connect('toggle-tray-show',
                                    self.__toogle_tray_cb)
+        self._view_toolbar.connect('toggle-inverted-colors',
+                                   self.__toggle_inverted_colors_cb)
         view_toolbar_button = ToolbarButton(page=self._view_toolbar,
                                             icon_name='toolbar-view')
         self._view_toolbar.show()
@@ -516,6 +518,10 @@ class ReadActivity(activity.Activity):
         else:
             logging.debug('Hide tray')
             self.tray.hide()
+
+    def __toggle_inverted_colors_cb(self, button, active):
+        if hasattr(self._view._model, 'set_inverted_colors'):
+            self._view._model.set_inverted_colors(active)
 
     def __num_page_entry_insert_text_cb(self, entry, text, length, position):
         if not re.match('[0-9]', text):
@@ -994,6 +1000,7 @@ class ReadActivity(activity.Activity):
         else:
             import evinceadapter
             self._view = evinceadapter.EvinceViewer()
+            self._view_toolbar.show_inverted_colors_button()
 
         self._view.setup(self)
         self._view.load_document(filepath)
@@ -1182,6 +1189,9 @@ class ReadActivity(activity.Activity):
             return True
         elif keyname == 'KP_End':
             self._view_toolbar.zoom_out()
+            return True
+        elif keyname == 'i' and event.state & Gdk.ModifierType.CONTROL_MASK:
+            self._view_toolbar.toggle_inverted_colors()
             return True
         elif keyname == 'Home':
             self._view.scroll(Gtk.ScrollType.START, False)

--- a/readtoolbar.py
+++ b/readtoolbar.py
@@ -177,7 +177,9 @@ class ViewToolbar(Gtk.Toolbar):
         'toggle-index-show': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE,
                               ([bool])),
         'toggle-tray-show': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE,
-                             ([bool])), }
+                             ([bool])),
+        'toggle-inverted-colors': (GObject.SignalFlags.RUN_FIRST,
+                                   GObject.TYPE_NONE, ([bool])), }
 
     def __init__(self):
         Gtk.Toolbar.__init__(self)
@@ -260,6 +262,17 @@ class ViewToolbar(Gtk.Toolbar):
         self.insert(self._rotate_right, -1)
         self._rotate_right.show()
 
+        spacer = Gtk.SeparatorToolItem()
+        self.insert(spacer, -1)
+        spacer.show()
+
+        self._inverted_colors = ToggleToolButton(icon_name='dark-theme')
+        self._inverted_colors.set_tooltip(_('Inverted Colors'))
+        self._inverted_colors.set_accelerator('<Ctrl>i')
+        self._inverted_colors.connect(
+            'toggled', self.__inverted_colors_toggled_cb)
+        self.insert(self._inverted_colors, -1)
+
     def set_view(self, view):
         self._view = view
         self._update_zoom_buttons()
@@ -324,3 +337,19 @@ class ViewToolbar(Gtk.Toolbar):
             self.traybutton.set_tooltip(_('Show Tray'))
         else:
             self.traybutton.set_tooltip(_('Hide Tray'))
+
+    def __inverted_colors_toggled_cb(self, button):
+        self.emit('toggle-inverted-colors', button.props.active)
+        if button.props.active:
+            button.set_icon_name('light-theme')
+            button.set_tooltip(_('Normal Colors'))
+        else:
+            button.set_icon_name('dark-theme')
+            button.set_tooltip(_('Inverted Colors'))
+
+    def show_inverted_colors_button(self):
+        self._inverted_colors.show()
+
+    def toggle_inverted_colors(self):
+        self._inverted_colors.set_active(
+            not self._inverted_colors.get_active())


### PR DESCRIPTION
Fixes #34 

**Issues**
1) I have not added an icon for the invert toggle button. I am a bad designer and I could not find suitable icons online
2) The invert color button can be clicked even when no PDF is loaded. Its behaviour is similar to that of the favourite button. However, it should be such that only when a PDF is loaded, can the button be clicked.

Kindly guide me on how I can proceed with the above two issues.

Tested on Sugar v0.114 and Ubuntu 18.04 